### PR TITLE
Resolve problems with "Meuse_whole_model.cfg" test case

### DIFF
--- a/dfastbe/batch.py
+++ b/dfastbe/batch.py
@@ -1795,10 +1795,11 @@ def get_zoom_extends(km_min: float, km_max: float, zoom_km_step: float, bank_crd
             range_crds = bank_crds[ib][irange, :]
             x = range_crds[:, 0]
             y = range_crds[:, 1]
-            xmin = min(xmin, min(x))
-            xmax = max(xmax, max(x))
-            ymin = min(ymin, min(y))
-            ymax = max(ymax, max(y))
+            if len(x) > 0:
+                xmin = min(xmin, min(x))
+                xmax = max(xmax, max(x))
+                ymin = min(ymin, min(y))
+                ymax = max(ymax, max(y))
         xyzoom.append((xmin, xmax, ymin, ymax))
 
     return kmzoom, xyzoom

--- a/dfastbe/kernel.py
+++ b/dfastbe/kernel.py
@@ -401,12 +401,14 @@ def get_km_eroded_volume(
     dvol : numpy.ndarray
         Array containing the accumulated eroded volume per chainage bin.
     """
-    bin_idx = numpy.rint((bank_km_mid - km_bin[0] - km_bin[2] / 2) / km_bin[2]).astype(
+    km_step = km_bin[2]
+    nbins = int(math.ceil((km_bin[1] - km_bin[0]) / km_step))
+
+    bin_idx = numpy.rint((bank_km_mid - km_bin[0] - km_step / 2.0) / km_step).astype(
         numpy.int64
     )
     dvol = numpy.bincount(bin_idx, weights=dv)
-    length = int((km_bin[1] - km_bin[0]) / km_bin[2])
-    dvol.resize((length,))
+    dvol.resize((nbins,))
     return dvol
 
 


### PR DESCRIPTION
1) When zooming take into account that one (or more) of the bank lines may not exist in the zoomed region. (batch.py)
2) Make sure that the binned erosion volume has the same length as the km_mid array (since the dvol array in batch.py/bankerosion_core routine has been pre-allocated with that length)