### PR TITLE
Remove Nuitka specific code lines #47

### DIFF
--- a/src/dfastbe/__main__.py
+++ b/src/dfastbe/__main__.py
@@ -29,29 +29,7 @@ This file is part of D-FAST Bank Erosion: https://github.com/Deltares/D-FAST_Ban
 
 from typing import Optional, Tuple
 
-# ------------------------------------------------------------------------------
-# Needed for Nuitka compilation
-# ------------------------------------------------------------------------------
-import os
-import pathlib
-
-is_nuitka = "__compiled__" in globals()
-if is_nuitka:
-    root = str(pathlib.Path(__file__).parent)
-    os.environ["GDAL_DATA"] = root + os.sep + "gdal"
-    os.environ["PROJ_LIB"] = root + os.sep + "proj"
-    os.environ["MATPLOTLIBDATA"] = root + os.sep + "matplotlib" + os.sep + "mpl-data"
-    os.environ["TCL_LIBRARY"] = root + os.sep + "lib" + os.sep + "tcl8.6"
-    proj_lib_dirs = os.environ.get("PROJ_LIB", "")
-    import pyproj.datadir
-
-    pyproj.datadir.set_data_dir(root + os.sep + "proj")
-    import pyproj
-
-
-# ------------------------------------------------------------------------------
 import matplotlib
-
 matplotlib.use("Qt5Agg")
 
 import argparse


### PR DESCRIPTION
We needed some special commands in `__main__` when originally developing the first version of D-FAST BE. Using the latest settings, we can remove those ad hoc changes.