### PR TITLE
Set version constraint for Pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pandas = "^1.5.3"
 matplotlib = "3.8.4"
 geopandas = "^0.14.4"
 shapely = "^2.1.0"
+Pillow = ">=11.3.0"  # Ensure Pillow is at least version 11.3.0 CWE-122
 dfastio = { git = "https://github.com/Deltares/D-FAST_Commons.git", tag = "0.1.0-alpha.2" }
 certifi = "2025.1.31"
 


### PR DESCRIPTION
# Description

Pillow has a security vulnerability which affects versions: >= 11.2.0, < 11.3.0
The library matplotlib has a dependency on Pillow, but doesn't have any versions that require a high enough Pillow version, to fix this vulnerability.


# Issues
- Fixes #135


## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
- [x] My branch is updated with the latest changes from the base branch.
- [ ] All pipelines are green?
- [ ] Mkdocs docs is updated with my changes (the examples look as they should in the github pages). 
- [ ] Assigned copilot as a reviewer and addressed the copilot's comments.
- [ ] Updated version number in pyproject.toml.
- [ ] Updated the lock file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Documentation (docstring/existing mkdocs files) are updated.
