### PR TITLE
Drop the old agent requirement for WindowsSDKv10.0 for LaTeX manuals build

### DIFF
--- a/.teamcity/DFastBETests/latex_manual.kt
+++ b/.teamcity/DFastBETests/latex_manual.kt
@@ -103,8 +103,4 @@ object LatexManual : BuildType({
             }
         }
     }
-
-    requirements {
-        exists("WindowsSDKv10.0")
-    }
 })


### PR DESCRIPTION
# Description

- Removed old agent requirement


# Issues
- Fixes DFAST-314

