### PR TITLE
Write permissions for publishing the MkDocs of the main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - master
+
+permissions:
+  pages: write        # required to publish to GitHub Pages
+  id-token: write     # required for actions/deploy-pages
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/synch-to-gitlab.yml
+++ b/.github/workflows/synch-to-gitlab.yml
@@ -11,7 +11,8 @@ jobs:
         with:
          fetch-depth: 0
       - name: Sync to GitLab
-        uses: yesolutions/mirror-action@master
+        uses: yesolutions/mirror-action@1708f16cdb28634fd3ba10c5c79abc91f5578a14
+
         with:
           REMOTE: https://open-git.deltares.nl/deltares-github-backups/${{ github.event.repository.name }}.git
           GIT_USERNAME: ${{ secrets.GITLAB_USERNAME }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run image
-        uses: abatilo/actions-poetry@v4
+        uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1
         with:
           poetry-version: 1.8.4
       - name: Cache Poetry virtualenv
@@ -52,6 +52,6 @@ jobs:
       - name: Test with pytest
         run: poetry run pytest --cov --cov=src/dfastbe --cov-report term-missing -m "not binaries"
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
# Description

- set write permissions for docs.yml
- fix GitHub revisions with specific hash instead of using latest or approximate version number (SonarQube security issue)

# Issues
- Fixes #192 


## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:
- [ ] My branch is updated with the latest changes from the base branch.
- [ ] All pipelines are green?
- [ ] Mkdocs docs is updated with my changes (the examples look as they should in the github pages). 
- [ ] Assigned copilot as a reviewer and addressed the copilot's comments.
- [ ] Updated version number in pyproject.toml.
- [ ] Updated the lock file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Documentation (docstring/existing mkdocs files) are updated.
